### PR TITLE
Fix formatting & minor typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # pushwatch
 #### The online GCM and APNS Tester
 
-Pushwatch is an online open-source project that hels test GCM and APNS push notifications on android and apple devices. pushwatch is available under
+Pushwatch is an online open-source project that helps test GCM and APNS push notifications on android and apple devices. pushwatch is available under
 [MIT Licence](https://opensource.org/licenses/MIT) and is free to use for anyone. You can either host pushwatch on your own servers or simply use it @ [www.pushwatch.com](http://www.pushwatch.com).
 
 Pushwatch consists of 2 parts:
 
-####[Test GCM push notifications](http://www.pushwatch.com/gcm/)
+### [Test GCM push notifications](http://www.pushwatch.com/gcm/)
 GCM push notification tester allows you to send, test and debug GCM push notifications to android devices. Using this free online tester you can send both a simple and a JSON push notifications to your android devices.
 
-####[Test APNS push notifications](http://www.pushwatch.com/apns/)
+### [Test APNS push notifications](http://www.pushwatch.com/apns/)
 APNS push notification tester allows you to send, test and debug APNS push notifications to iOS devices. Using this free online tester you can send both a simple and a JSON push notification to your apple devices.
 
 pushwatch is proudly powered by [django](https://www.djangoproject.com/) and [django-instapush](https://github.com/amyth/django-instapush).


### PR DESCRIPTION
This fixes the section headers to be properly rendered, and corrects `hels` to `helps`.

Preview:

<img width="1424" alt="image" src="https://user-images.githubusercontent.com/6340841/72552657-32d96780-384c-11ea-8b99-ad1323d8ce79.png">
